### PR TITLE
Feature/remove font family

### DIFF
--- a/source/stylesheets/common/_base.sass
+++ b/source/stylesheets/common/_base.sass
@@ -2,7 +2,6 @@
   background-color: transparent
   border: 0
   box-sizing: border-box
-  font-family: font-family()
   font-weight: 400
   text-decoration: none
 

--- a/source/stylesheets/components/_body.sass
+++ b/source/stylesheets/components/_body.sass
@@ -1,3 +1,5 @@
 .body
+  font-family: 'Arial', sans-serif
+
   &--no-scroll
     overflow: hidden

--- a/source/stylesheets/components/_button.sass
+++ b/source/stylesheets/components/_button.sass
@@ -3,7 +3,6 @@
   border-radius: 4px
   color: get-color(gafieira)
   display: block
-  font-family: font-family()
   font-size: 14px
   padding: 12px
   text-align: center

--- a/source/stylesheets/components/_coming-soon.sass
+++ b/source/stylesheets/components/_coming-soon.sass
@@ -24,7 +24,6 @@
 
   &__title
     color: get-color(rock)
-    font-family: font-family()
     font-size: 24px
     font-weight: 300
     line-height: 34px
@@ -48,7 +47,6 @@
 
   &__subtitle
     color: get-color((color: dark, opacity: .6))
-    font-family: font-family()
     font-size: 14px
     font-weight: 700
     line-height: 19px

--- a/source/stylesheets/components/_form.sass
+++ b/source/stylesheets/components/_form.sass
@@ -18,7 +18,6 @@
     background-color: get-color(air)
     border: 1px solid get-color((color: dark, opacity: .1))
     border-radius: 4px
-    font-family: font-family()
     font-size: 14px
     line-height: 14px
     padding: 13px 10px

--- a/source/stylesheets/components/_headings.sass
+++ b/source/stylesheets/components/_headings.sass
@@ -1,7 +1,6 @@
 .page
   &__title
     color: get-color(gafieira)
-    font-family: font-family()
     font-size: 24px
     font-weight: 900
 

--- a/source/stylesheets/components/_navbar.sass
+++ b/source/stylesheets/components/_navbar.sass
@@ -46,7 +46,6 @@
     border-bottom: 3px solid transparent
     color: get-color(rock)
     display: block
-    font-family: font-family()
     font-size: 9px
     font-weight: 700
     line-height: 40px - 3px

--- a/source/stylesheets/components/_page-header.sass
+++ b/source/stylesheets/components/_page-header.sass
@@ -22,7 +22,6 @@
 
   &__title
     color: get-color(gafieira)
-    font-family: font-family()
     font-size: 24px
     font-weight: 700
     line-height: 31px
@@ -31,7 +30,6 @@
     small
       color: get-color(rock)
       display: block
-      font-family: font-family()
       font-size: 20px
       font-weight: 100
       margin-top: 5px

--- a/source/stylesheets/components/_pagination.sass
+++ b/source/stylesheets/components/_pagination.sass
@@ -26,7 +26,6 @@
   .pagination__link
     color: inherit
     display: block
-    font-family: font-family()
     font-size: 14px
     font-weight: 700
     padding: 7px 10px

--- a/source/stylesheets/components/_search.sass
+++ b/source/stylesheets/components/_search.sass
@@ -11,7 +11,6 @@
 
   &__title
     color: get-color(rock)
-    font-family: font-family()
     font-size: 18px
     font-weight: 700
 
@@ -30,12 +29,10 @@
 
   &__for
     color: get-color(rock)
-    font-family: font-family()
     font-size: 14px
 
   &__query
     color: get-color(rock)
-    font-family: font-family()
     font-size: 24px
     font-weight: 700
 
@@ -74,7 +71,6 @@
 
   &__description
     color: get-color((color: dark, opacity: .6))
-    font-family: font-family()
     font-size: 12px
 
   &__infos

--- a/source/stylesheets/components/card/_headings.sass
+++ b/source/stylesheets/components/card/_headings.sass
@@ -1,7 +1,6 @@
 .card
   &__title
     color: get-color(rock)
-    font-family: font-family()
     font-size: 14px
     font-weight: 700
     margin: 0
@@ -34,7 +33,6 @@
 
   &__description
     color: get-color((color: rock, opacity: .8))
-    font-family: font-family()
     font-size: 12px
     margin-bottom: 0
     text-align: left
@@ -85,7 +83,6 @@
   &__additional-info
     color: get-color((color: dark, opacity: .4))
     display: inline-block
-    font-family: font-family()
     font-size: 11px
     margin: 0
     text-align: left
@@ -107,7 +104,6 @@
 
     span
       color: get-color((color: rock, opacity: .6))
-      font-family: font-family()
       font-size: 12px
       height: 10px
       line-height: 10px

--- a/source/stylesheets/functions/_font_family.sass
+++ b/source/stylesheets/functions/_font_family.sass
@@ -1,2 +1,0 @@
-@function font-family($name: $base-font)
-  @return '#{$name}', 'Arial', sans-serif

--- a/source/stylesheets/main.sass
+++ b/source/stylesheets/main.sass
@@ -2,13 +2,11 @@
 
 @import variables/breakpoints
 @import variables/colors
-@import variables/fonts
 @import variables/grid
 @import variables/z-index
 
 @import functions/get
 @import functions/get_color
-@import functions/font_family
 
 @import common/base
 

--- a/source/stylesheets/variables/_fonts.sass
+++ b/source/stylesheets/variables/_fonts.sass
@@ -1,3 +1,0 @@
-$base-font: 'Arial'
-
-$font-weight: (normal: 400, bold: 700)


### PR DESCRIPTION
Seguindo o fluxo da remoção de dependência da fonte do Guide, esse PR tem como objetivo tirar a função `font-family()` onde era chamada.

Em compensação, setamos `font-family: 'Arial', sans-serif` no body como default, e sobrescreveremos no Dança para `Nunito`.

___

Assim que aprovado por um, farei o build da versão. 😉 